### PR TITLE
fix problem on const inside command.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -206,6 +206,8 @@ module.exports = async function compile(fileName, ctx, config) {
                 const name = cmd.offset;
                 cmd.op = 'number'
                 cmd.num = getConstantValue(ctx, name);
+                cmd.offsetLabel = name;
+                delete cmd.offset;
                 return;
             }
             else {

--- a/test/consts_command.zkasm
+++ b/test/consts_command.zkasm
@@ -1,0 +1,18 @@
+start:
+
+        STEP => A
+        0 :ASSERT
+
+CONSTL %MAXL = (1 << 256) - 1
+        115792089237316195423570985008687907853269984665640564039457584007913129639935n => A
+        %MAXL :ASSERT
+        ${const.MAXL} :ASSERT
+        ${115792089237316195423570985008687907853269984665640564039457584007913129639935} :ASSERT
+
+end:
+       0 => A,B,C,D,E,CTX, SP, PC, GAS, MAXMEM, SR
+
+finalWait:
+        ${beforeLast()}  : JMPN(finalWait)
+
+                         : JMP(start)


### PR DESCRIPTION
When compile a constant inside command, left offset as name of constant, but it's incoherent with other situations of compiler. It's fixed and left name of value on offsetLabel as used in other places. A new property, as name, has not been used to avoid other problems in zkproverc.